### PR TITLE
Generate RPMs with the correct dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ pip-log.txt
 
 html
 test-reports
+
+setup.cfg

--- a/bdist_rpm.sh
+++ b/bdist_rpm.sh
@@ -29,52 +29,51 @@
 # to indicate their contents in a more appropriate way. We do not do this for the packages when shipped to
 # PyPi, since it is pretty obvious these are Python packages in any case.
 
-all_packages=
+all_packages=vsc-ldap
 edit=
 release=
 
 while getopts er:p:h name
 do
-  case $name in
-    e) edit="-e";;
-    r) release="$OPTARG";;
-    p) all_packages="$OPTARG";;
-    h) printf "Usage: %s [-e] [-r RELEASE] [-p PACKAGE]" $0
-       echo
-       echo "  -e            Edit the generated spec file before rebuilding the RPM"
-       echo "  -r [RELEASE]  Specify the RELEASE tag given to the RPM. Automagically adds .ug.noarch"
-       echo "  -p [PACKAGE]  Specify a single PACKAGE to be built. Default builds all packages."
-       exit 1;;
-  esac
+    case $name in
+	e) edit="-e";;
+	r) release="$OPTARG";;
+	p) all_packages="$OPTARG";;
+	h) printf "Usage: %s [-e] [-r RELEASE] [-p PACKAGE]" $0
+	    echo
+	    echo "  -e            Edit the generated spec file before rebuilding the RPM"
+	    echo "  -r [RELEASE]  Specify the RELEASE tag given to the RPM. Automagically adds .ug.noarch"
+	    echo "  -p [PACKAGE]  Specify a single PACKAGE to be built. Default builds all packages."
+	    exit 1;;
+    esac
 done
 
-if [ -z "$all_packages" ]; then
-  ALL_PACKAGES=`python ./setup.py --name 2>/dev/null | grep -v "removing 'build'" | tr "\n" " "`
-else
-  ALL_PACKAGES=$all_packages
+
+package=$all_packages
+echo $package
+python ./setup.py bdist_rpm
+rpm_target=`ls dist/${package}*noarch.rpm`
+rpm_target_name=`basename ${rpm_target}`
+
+if ! [ -f "setup.cfg" ]
+then
+    echo "No setup.cfg. Refusing cowardly to continue."
+    exit 1
+fi
+  # user specified requirements can be found in setup.cfg
+requirements=`grep "requires" setup.cfg | cut -d" " -f3- | tr "," "\n" | grep -vE "(^python-)|(-python$)" | tr "\n" "|" | sed -e 's/|$//'`
+if [ -z "$requirements" ]; then
+    echo "No requirements found. Refusing cowardly to continue."
+    exit 1
 fi
 
-for package in $ALL_PACKAGES; do
-
-  echo $package
-  python ./setup.py bdist_rpm
-  rpm_target=`ls dist/${package}*noarch.rpm`
-  rpm_target_name=`basename ${rpm_target}`
-
-  # user specified requirements can be found in setup.cfg
-  requirements=`grep "requires" setup.cfg | cut -d" " -f3- | tr "," "|"`
-  if [ -z "$requirements" ]; then
-    requirements="no-match-etc-etc-etc"
-  fi
-
-  if [ -z "$release" ]; then
+if [ -z "$release" ]; then
     release="\\2"
-  fi
+fi
 
-  rpmrebuild --define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
-             --change-spec-preamble="sed -e 's/^Name:\(\s\s*\)\(.*\)/Name:\1python-\2/'" \
-             --change-spec-provides="sed -e 's/${package}/python-${package}/g'" \
-             --change-spec-requires="sed -r 's/^Requires:(\s\s*)(${requirements})/Requires:\1python-\2/'" \
-             --change-spec-preamble="sed -e 's/^\(Release:\s\s*\)\(.*\)\s*$/\1${release}.ug/'" \
-             ${edit} -n -p ${rpm_target}
-done
+rpmrebuild --define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
+    --change-spec-preamble="sed -e 's/^Name:\(\s\s*\)\(.*\)/Name:\1python-\2/'" \
+    --change-spec-provides="sed -e 's/${package}/python-${package}/g'" \
+    --change-spec-requires="sed -r 's/^Requires:(\s\s*)(${requirements})/Requires:\1python-\2/'" \
+    --change-spec-preamble="sed -e 's/^\(Release:\s\s*\)\(.*\)\s*$/\1${release}.ug/'" \
+    ${edit} -n -p ${rpm_target}

--- a/shared_setup.py
+++ b/shared_setup.py
@@ -264,7 +264,6 @@ def action_target(target, setupfn=setup, extra_sdist=[]):
     x = parse_target(target)
 
     setupfn(**x)
-    cleanup()
 
 if __name__ == '__main__':
     # print all supported packages


### PR DESCRIPTION
The setup.cfg file is important, and the shared_setup.py was removing
it, wrongly. This lead to wrong dependencies in the RPMs as discussed in #13.
