### PR TITLE
Fix empty gecos sync

### DIFF
--- a/lib/vsc/ldap/utils.py
+++ b/lib/vsc/ldap/utils.py
@@ -491,6 +491,9 @@ class LdapQuery(object):
         current_ = {}
         for key in attributes.keys():
             current_[key] = current.get(key, [])
+            if current_[key] is '':
+                self.log.warning("Replacing empty string for key %s with foo before making modlist for dn %s" % (key, dn))
+                current_[key] = "foo"  # hack to allow replacing empty strings
         # [(ldap.MOD_REPLACE, k, v) for (k,v) in attributes.iteritems()]
         modification_attributes = ldap.modlist.modifyModlist(current_, attributes)
 

--- a/lib/vsc/ldap/utils.py
+++ b/lib/vsc/ldap/utils.py
@@ -43,6 +43,8 @@ from vsc.utils.fancylogger import getLogger
 from vsc.utils.missing import TryOrFail
 from vsc.utils.patterns import Singleton
 
+EMPTY_GECOS_DURING_MODIFY="EMPTYGECOSDURINGMODIFY"
+
 
 class LdapConfiguration(object):
     """Represents some LDAP configuration.
@@ -492,8 +494,9 @@ class LdapQuery(object):
         for key in attributes.keys():
             current_[key] = current.get(key, [])
             if current_[key] is '':
-                self.log.warning("Replacing empty string for key %s with EMPTYGECOSDURINGMODIFY before making modlist for dn %s" % (key, dn))
-                current_[key] = "EMPTYGECOSDURINGMODIFY"  # hack to allow replacing empty strings
+                self.log.warning("Replacing empty string for key %s with %s before making modlist for dn %s" %
+                                 (key, EMPTY_GECOS_DURING_MODIFY, dn))
+                current_[key] = EMPTY_GECOS_DURING_MODIFY  # hack to allow replacing empty strings
         # [(ldap.MOD_REPLACE, k, v) for (k,v) in attributes.iteritems()]
         modification_attributes = ldap.modlist.modifyModlist(current_, attributes)
 

--- a/lib/vsc/ldap/utils.py
+++ b/lib/vsc/ldap/utils.py
@@ -492,8 +492,8 @@ class LdapQuery(object):
         for key in attributes.keys():
             current_[key] = current.get(key, [])
             if current_[key] is '':
-                self.log.warning("Replacing empty string for key %s with foo before making modlist for dn %s" % (key, dn))
-                current_[key] = "foo"  # hack to allow replacing empty strings
+                self.log.warning("Replacing empty string for key %s with EMPTYGECOSDURINGMODIFY before making modlist for dn %s" % (key, dn))
+                current_[key] = "EMPTYGECOSDURINGMODIFY"  # hack to allow replacing empty strings
         # [(ldap.MOD_REPLACE, k, v) for (k,v) in attributes.iteritems()]
         modification_attributes = ldap.modlist.modifyModlist(current_, attributes)
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ PACKAGE = {
         'vsc-base >= 1.7.0',
         'python-ldap'
     ],
-    'version': '1.3.2',
+    'version': '1.3.3',
     'author': [ag, kh, sdw, wdp],
     'maintainer': [ag],
     'packages': ['vsc', 'vsc.ldap'],


### PR DESCRIPTION
When the gecos is empty in the exiting LDAP attributes, the modest only contains a _new_ entry, e.g., 

~~~~
[(0, 'gecos', 'Foo Bar')]
~~~~

instead of the exiting entry and its replacement, like

~~~~
[(1, 'gecos', None), (0, 'gecos', 'Foo Bar')]
~~~~

This means that the LDAP modification call will assume we _add_ an item, but gecos can only hold a single attribute, i.e., it is not a list. Because the original item always contains None in the modification list, we can safely fake a non-empty existing entry value.